### PR TITLE
change handler to only local logger

### DIFF
--- a/datazets/datazets.py
+++ b/datazets/datazets.py
@@ -17,13 +17,12 @@ import fnmatch
 from io import BytesIO
 from urllib.parse import urlparse
 
-logger = logging.getLogger('')
+logger = logging.getLogger(__name__)
 [logger.removeHandler(handler) for handler in logger.handlers[:]]
 console = logging.StreamHandler()
 formatter = logging.Formatter('[datazets] >%(levelname)s> %(message)s')
 console.setFormatter(formatter)
 logger.addHandler(console)
-logger = logging.getLogger(__name__)
 
 
 # %% Import example dataset.


### PR DESCRIPTION
All handlers are removed from the root logger and replace by a handler which logs with "[d3graph]" prefix. This causes that this prefix appears in logs from other modules. It also interferes with pytest log handles.
This PR performs the handler replacement only for the local logger.